### PR TITLE
Ensure Mix is loaded

### DIFF
--- a/lib/private.ex
+++ b/lib/private.ex
@@ -25,7 +25,11 @@ defmodule Private do
 
   defmacro private(do:  block) do
     quote do
-      unquote(do_private(block, Mix.env))
+      if Code.ensure_loaded?(Mix) do
+        unquote(do_private(block, Mix.env))
+      else
+        unquote(block)
+      end
     end
   end
 


### PR DESCRIPTION
Sometimes Mix doesn't exists at compile time (for example, when hot-reloading a module in a release), this code just ensure that `Mix` exists before calling it, and if it doesn't exists it just return the block